### PR TITLE
home page: add and style all current sponsors to list

### DIFF
--- a/app/assets/stylesheets/pages.css.scss
+++ b/app/assets/stylesheets/pages.css.scss
@@ -128,13 +128,8 @@ $include-html-global-classes: false;
 .sponsors {
   background-color: $hackedu-white;
 
-  .logos {
+  .columns {
     margin-top: 30px;
-
-    img {
-      margin-bottom: 2em;
-      height: auto;
-    }
   }
 
   h1 {
@@ -146,10 +141,10 @@ $include-html-global-classes: false;
   }
 
   img {
-    height: 50px;
+    margin-bottom: 2em;
 
     @media #{$medium-up} {
-      height: 80px;
+      width: 75%;
     }
   }
 }

--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -39,14 +39,60 @@
 #home-map-jumbotron
 .main-section.sponsors
   %h1 Sponsors
-  .row.logos
-    %ul.small-block-grid-1.medium-block-grid-2
-      %li= image_tag 'sponsors/codehs.png', alt: 'CodeHS'
-      %li= image_tag 'sponsors/hackreactor.png', alt: 'Hack Reactor'
-      %li= image_tag 'sponsors/workflowy.png', alt: 'Workflowy'
-      %li= image_tag 'sponsors/makeschool.svg', alt: 'Make School'
-      %li= image_tag 'sponsors/nitrousio.svg', alt: 'Nitrous.IO'
-      %li= image_tag 'sponsors/rackspace.svg', alt: 'Rackspace'
+  .show-for-small-only
+    .row.logos
+      .small-6.columns
+        = link_to "https://taplytics.com/" do
+          %img{alt: 'Taplytics', src: '/assets/taplytics.svg'}
+        = link_to "http://www.hackreactor.com/" do
+          %img{alt: 'Hack Reactor', src: '/assets/hack_reactor.png'}
+        = link_to "https://workflowy.com/" do
+          %img{alt: 'Workflowy', src: '/assets/workflowy.png'}
+        = link_to "http://firstcodeacademy.com/" do
+          %img{alt: 'First Code Academy', src: '/assets/first_code_academy.png'}
+      .small-6.columns
+        = link_to "https://www.makeschool.com" do
+          %img{alt: 'Make School', src: '/assets/make_school.svg'}
+        = link_to "https://www.nitrous.io/" do
+          %img{alt: 'nitrous.io', src: '/assets/nitrousio.svg'}
+        = link_to "http://www.rackspace.com/" do
+          %img{alt: 'Rackspace', src: '/assets/rackspace.svg'}
+        = link_to "https://codehs.com/" do
+          %img{alt: 'CodeHS', src: '/assets/codehs.png'}
+      .small-6.small-centered.columns
+        = link_to "https://sourcegraph.com/" do
+          %img{alt: 'Sourcegraph', src: '/assets/sourcegraph.png'}
+  .show-for-medium-up
+    .row.logos
+      .medium-4.columns
+        = link_to "https://taplytics.com/" do
+          %img{alt: 'Taplytics', src: '/assets/taplytics.svg'}
+      .medium-4.columns
+        = link_to "http://www.hackreactor.com/" do
+          %img{alt: 'Hack Reactor', src: '/assets/hack_reactor.png'}
+      .medium-4.columns
+        = link_to "https://workflowy.com/" do
+          %img{alt: 'Workflowy', src: '/assets/workflowy.png'}
+    .row.logos
+      .medium-4.columns
+        = link_to "https://sourcegraph.com/" do
+          %img{alt: 'Sourcegraph', src: '/assets/sourcegraph.png'}
+      .medium-4.columns
+        = link_to "https://www.makeschool.com" do
+          %img{alt: 'Make School', src: '/assets/make_school.svg'}
+      .medium-4.columns
+        = link_to "https://www.nitrous.io/" do
+          %img{alt: 'nitrous.io', src: '/assets/nitrousio.svg'}
+    .row.logos
+      .medium-4.columns
+        = link_to "http://www.rackspace.com/" do
+          %img{alt: 'Rackspace', src: '/assets/rackspace.svg'}
+      .medium-4.columns
+        = link_to "https://codehs.com/" do
+          %img{alt: 'CodeHS', src: '/assets/codehs.png'}
+      .medium-4.columns
+        = link_to "http://firstcodeacademy.com/" do
+          %img{alt: 'First Code Academy', src: '/assets/first_code_academy.png'}
 .email-form.small-section
   .row
     %h1 Stay in the loop


### PR DESCRIPTION
This corrects the features lost in merging the sponsor-list branch. It lists all sponsors on the main page and adds mobile responsiveness:
![screenshot 2015-03-23 at 2 58 47 am](https://cloud.githubusercontent.com/assets/5891442/6777695/45103442-d109-11e4-817a-3d23e39b22cc.png)
