### PR TITLE
home: comparison metrics are underneath metric descriptions

### DIFF
--- a/app/assets/stylesheets/pages.css.scss
+++ b/app/assets/stylesheets/pages.css.scss
@@ -108,10 +108,16 @@ $include-html-global-classes: false;
 
     .stat-desc {
       font-size: rem-calc(24);
+      margin-bottom: rem-calc(6);
 
       @media #{$medium-up} {
         font-size: rem-calc(28);
       }
+    }
+
+    .stat-comparison {
+      color: $hackedu-white;
+      font-size: rem-calc(12);
     }
   }
 }

--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -10,14 +10,18 @@
   .row
     %h1 Our Impact
     .small-12.medium-4.columns.metric
+      %p.stat 32%
+      %p.stat-desc Women
+      = link_to 'http://research.collegeboard.org/programs/ap/data/participation/ap-2014' do
+        %p.stat-comparison 20% of AP CS test takers are female
+    .small-12.medium-4.columns.metric
       %p.stat 1,300
       %p.stat-desc Students Reached
     .small-12.medium-4.columns.metric
-      %p.stat 32%
-      %p.stat-desc Women
-    .small-12.medium-4.columns.metric
       %p.stat 37%
       %p.stat-desc Minorities in Tech
+      = link_to 'http://www.edweek.org/ew/articles/2014/12/19/more-students-but-few-girls-minorities-took-ap-computer.html' do
+        %p.stat-comparison 13% of AP CS test takers in 2014 were African-American or Hispanic
     .small-12.medium-6.medium-centered.columns.metric
       .small-12.medium-6.columns.metric
         %p.stat 11


### PR DESCRIPTION
![screenshot 2015-08-18 at 4 10 55 pm](https://cloud.githubusercontent.com/assets/5891442/9345352/cde76170-45c4-11e5-8701-a96868be5ae8.png)
