### PR TITLE
Update footer links

### DIFF
--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -173,6 +173,8 @@
             #{link_to 'GitHub', 'https://github.com/hackclub'}
           %li.link
             = link_to 'Join us on IRC', 'https://kiwiirc.com/client/irc.freenode.net/?nick=Hacker%7C?#hackclub'
+          %li.link
+            #{link_to 'Slack', 'https://slack.hackclub.io/'}
       .small-12.medium-4.columns.nav
         %h1 Social
         %ul

--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -179,6 +179,8 @@
         %h1 Social
         %ul
           %li.link
+            #{link_to 'Blog', 'https://blog.hackclub.io'}
+          %li.link
             #{link_to 'Facebook', 'https://www.facebook.com/pages/hackEDU/741805665870458'}
           %li.link
             #{link_to 'Twitter', 'https://twitter.com/starthackclub'}


### PR DESCRIPTION
I'm adding https://blog.hackclub.io to the footer because we are planning on consolidating this link anyways

_[sauce](https://github.com/hackclub/meta/issues/355#issuecomment-161472802)_
