### PR TITLE
Make application's year question more friendly

### DIFF
--- a/app/models/club_application.rb
+++ b/app/models/club_application.rb
@@ -4,7 +4,17 @@ class ClubApplication < ActiveRecord::Base
   validates_uniqueness_of :email
   validates_email_format_of :email, message: 'not a valid email'
 
-  enum year: [:freshman, :sophomore, :junior, :senior]
+  enum year: {
+    below_high_school: 4,
+    nine: 0,
+    ten: 1,
+    eleven: 2,
+    twelve: 3,
+    college_student: 5,
+    teacher: 6,
+    parent_or_guardian: 7,
+    other: 8
+  }
 
   def mail_address
     expected = Mail::Address.new email

--- a/app/views/club_applications/new.html.haml
+++ b/app/views/club_applications/new.html.haml
@@ -22,7 +22,9 @@
         .small-6.columns
           = f.input :high_school, placeholder: 'Visalia High School'
         .small-6.columns
-          = f.input :year
+          = f.input :year, as: :select,
+              collection: ClubApplication.years.to_a.map { |y| [y[0].humanize, y[0]] },
+              include_blank: true
       .row
         .large-6.columns
           .row.collapse


### PR DESCRIPTION
Options before this change:
- freshman
- sophomore
- junior
- senior

Options after this change:
- Below high school
- Nine
- Ten
- Eleven
- Twelve
- College student
- Teacher
- Parent or guardian
- Other

The change from freshman -> nine, sophomore -> ten, and so on makes the form more friendly to international applicants because the American terminology for grades is, well... American.

The addition of the other form fields makes the application friendlier to any applicant that's not in high school (most notably middle schoolers and teachers).

Closes #201.

Screenshot of what the form now looks like:

![tmp](https://cloud.githubusercontent.com/assets/992248/14339934/3351024a-fc37-11e5-9555-15253f94b716.png)
