### PR TITLE
Temporarily remove map on home page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,6 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 gem 'foundation-rails'
 gem 'rails-assets-Hover'
 gem 'rails-assets-underscore'
-gem 'gmaps4rails'
 gem 'simple_form'
 gem 'enum_help'
 gem 'pluggable_js'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,6 @@ GEM
     foundation-rails (5.4.5.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    gmaps4rails (2.1.2)
     guard (2.10.3)
       formatador (>= 0.2.4)
       listen (~> 2.7)
@@ -284,7 +283,6 @@ DEPENDENCIES
   faker
   figaro
   foundation-rails
-  gmaps4rails
   guard-rspec
   haml-rails
   jbuilder (~> 2.0)

--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -98,7 +98,6 @@
           %h1 Join Us
         .small-12.medium-6.columns
           = link_to 'Start a Hack Club', apply_path, class: 'button outline-outward'
-#home-map-jumbotron
 .main-section.sponsors
   .row
     %h1 Supporters


### PR DESCRIPTION
As of the time this PR is being written, the gem we are using for the map on our homepage is [https://travis-ci.org/apneadiving/Google-Maps-for-Rails/builds/129553203](not working). Let's remove the map until it is fixed upstream.
