### PR TITLE
Use intermediate info page in apply process

### DIFF
--- a/app/assets/stylesheets/pages.css.scss
+++ b/app/assets/stylesheets/pages.css.scss
@@ -855,3 +855,24 @@ a {
   font-size: 24px;
   line-height: 0;
 }
+
+.apply-header {
+  font-size: 28px;
+  margin-top: 15px;
+  text-align: center;
+
+  @media #{$medium-up} {
+    font-size: 48px;
+    margin-top: 40px;
+  }
+}
+
+.apply-info {
+  margin-top: 10px;
+  text-align: center;
+
+  @media #{$medium-up} {
+    margin-bottom: 30px;
+    margin-top: 20px;
+  }
+}

--- a/app/views/club_applications/new.html.haml
+++ b/app/views/club_applications/new.html.haml
@@ -4,10 +4,15 @@
                         ' rolling basis each semester.'
 
 .row
-  %h1 Apply
+  %h1.apply-header Apply to Start a Hack Club
 
 .row
-  %p We are currently accepting applications for the 2016 - 2017 school year.
+  .small-12.medium-9.small-centered.columns
+    %p.apply-info
+      We're currently accepting applications for the 2016 - 2017 school year. If
+      you have any questions, don't hesitate to email us at
+      #{ link_to 'apply@hackclub.com' }. We look for 2-3 sentence responses to
+      each question. Good luck!
 
 .row
   = simple_form_for @application, url: apply_path do |f|

--- a/app/views/layouts/_nav.html.haml
+++ b/app/views/layouts/_nav.html.haml
@@ -2,4 +2,4 @@
 %li= link_to 'Our Team', team_path
 %li= link_to 'Workshops', 'https://workshops.hackclub.com'
 %li= link_to 'Donate', donate_path
-%li.primary= link_to 'Start a Hack Club &raquo;'.html_safe, apply_path
+%li.primary= link_to 'Start a Hack Club &raquo;'.html_safe, '/start'

--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -2,7 +2,7 @@
   .row
     .large-6.medium-12.columns
       %h1 We help high schoolers start awesome after-school coding clubs.
-      = link_to apply_path,
+      = link_to '/start',
         class: 'button large outline-outward button-start-a-club' do
         Start a Hack Club <span class="raquo">&raquo;</span>
       %p.links.lead
@@ -162,7 +162,7 @@
     %h3 Interested in bringing a coding club to your school?
     %h3 All it takes to start a Hack Club is you!
     %p.links
-      = link_to apply_path,
+      = link_to '/start',
         class: 'button large outline-outward button-start-a-club' do
         Start a Hack Club <span class="raquo">&raquo;</span>
   .row.text-center.row-of-people.show-for-medium-up
@@ -222,7 +222,7 @@
         %h1 Useful Links
         %ul
           %li.link
-            #{link_to 'Start a Hack Club', apply_path}
+            #{link_to 'Start a Hack Club', '/start'}
           %li.link
             #{ link_to 'Workshops', 'https://workshops.hackclub.com/' }
           %li.link


### PR DESCRIPTION
This pull request makes two changes:

# The First

Previously if the user clicked the "Start a Hack Club" button, they were brought to `/apply`. Now they're brought to `/start` from `hackclub/frontend`, which has a whole lot more info on how Hack Club works, and then they're brought to `/apply` from there.

# The Second

Before:

![screen shot 2017-02-01 at 3 21 59 pm](https://cloud.githubusercontent.com/assets/992248/22530799/5bc00a08-e892-11e6-980c-df71bc2366b5.png)

After:

![screen shot 2017-02-01 at 3 22 05 pm](https://cloud.githubusercontent.com/assets/992248/22530811/66aab972-e892-11e6-8dae-c8bcb8341ab1.png)
