### PR TITLE
Add /sponsor page to robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,2 @@
-# See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
-#
-# To ban all spiders from the entire site uncomment the next two lines:
-# User-agent: *
-# Disallow: /
+User-agent: *
+Disallow: /sponsor


### PR DESCRIPTION
This PR adds `/sponsor` to the robots.txt file, so it's not scraped by web crawlers.