### PR TITLE
Add phone number as an optional requirement

### DIFF
--- a/app/controllers/club_applications_controller.rb
+++ b/app/controllers/club_applications_controller.rb
@@ -20,8 +20,9 @@ class ClubApplicationsController < ApplicationController
 
   def club_application_params
     params.require(:club_application).permit(:first_name, :last_name, :email,
-                                             :github, :twitter, :high_school,
-                                             :year, :interesting_project,
+                                             :phone_number, :github, :twitter,
+                                             :high_school, :year,
+                                             :interesting_project,
                                              :system_hacked, :steps_taken,
                                              :referer)
   end

--- a/app/views/club_applications/_club_application.text.erb
+++ b/app/views/club_applications/_club_application.text.erb
@@ -2,7 +2,7 @@ Name: <%= club_application.first_name %> <%= club_application.last_name %>
 High school: <%= club_application.high_school %>
 Year: <%= club_application.year %>
 Email: <%= club_application.email %>
-Phone Number: <%= if club_application.phone_number.blank? then 'N/A' else club_application.phone_number end %>
+Phone number: <%= club_application.phone_number %>
 GitHub: <%= club_application.github %>
 Twitter: <%= club_application.twitter %>
 

--- a/app/views/club_applications/_club_application.text.erb
+++ b/app/views/club_applications/_club_application.text.erb
@@ -2,7 +2,7 @@ Name: <%= club_application.first_name %> <%= club_application.last_name %>
 High school: <%= club_application.high_school %>
 Year: <%= club_application.year %>
 Email: <%= club_application.email %>
-Phone Number: <%= club_application.phone_number %>
+Phone Number: <%= if club_application.phone_number.blank? then 'N/A' else club_application.phone_number end %>
 GitHub: <%= club_application.github %>
 Twitter: <%= club_application.twitter %>
 

--- a/app/views/club_applications/_club_application.text.erb
+++ b/app/views/club_applications/_club_application.text.erb
@@ -2,6 +2,7 @@ Name: <%= club_application.first_name %> <%= club_application.last_name %>
 High school: <%= club_application.high_school %>
 Year: <%= club_application.year %>
 Email: <%= club_application.email %>
+Phone Number: <%= club_application.phone_number %>
 GitHub: <%= club_application.github %>
 Twitter: <%= club_application.twitter %>
 

--- a/app/views/club_applications/new.html.haml
+++ b/app/views/club_applications/new.html.haml
@@ -27,7 +27,7 @@
         .small-6.columns
           = f.input :email, placeholder: 'zaphod@beeblebrox.com'
         .small-6.columns
-          = f.input :phone_number, label: "Phone number (we'll get in touch to answer any questions you might have)",placeholder: '(555) 555-5555'
+          = f.input :phone_number, label: "Phone number (we'll get in touch to answer any questions you might have)", placeholder: '(555) 555-5555'
       .row
         .small-6.columns
           = f.input :high_school, placeholder: 'Visalia High School'

--- a/app/views/club_applications/new.html.haml
+++ b/app/views/club_applications/new.html.haml
@@ -24,8 +24,10 @@
         .small-6.columns
           = f.input :last_name, placeholder: 'Beeblebrox'
       .row
-        .columns
+        .small-6.columns
           = f.input :email, placeholder: 'zaphod@beeblebrox.com'
+        .small-6.columns
+          = f.input :phone_number, placeholder: '(555) 555-5555'
       .row
         .small-6.columns
           = f.input :high_school, placeholder: 'Visalia High School'

--- a/app/views/club_applications/new.html.haml
+++ b/app/views/club_applications/new.html.haml
@@ -27,7 +27,7 @@
         .small-6.columns
           = f.input :email, placeholder: 'zaphod@beeblebrox.com'
         .small-6.columns
-          = f.input :phone_number, placeholder: '(555) 555-5555'
+          = f.input :phone_number, label: "Phone number (we'll get in touch to answer any questions you might have)",placeholder: '(555) 555-5555'
       .row
         .small-6.columns
           = f.input :high_school, placeholder: 'Visalia High School'

--- a/db/migrate/20170207021033_add_phone_number_to_club_application.rb
+++ b/db/migrate/20170207021033_add_phone_number_to_club_application.rb
@@ -1,0 +1,5 @@
+class AddPhoneNumberToClubApplication < ActiveRecord::Migration
+  def change
+    add_column :club_applications, :phone_number, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161021142934) do
+ActiveRecord::Schema.define(version: 20170207021033) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 20161021142934) do
     t.datetime "updated_at"
     t.integer  "year"
     t.text     "referer"
+    t.string   "phone_number"
   end
 
   add_index "club_applications", ["email"], name: "index_club_applications_on_email", unique: true, using: :btree

--- a/spec/factories/club_applications.rb
+++ b/spec/factories/club_applications.rb
@@ -3,6 +3,7 @@ FactoryGirl.define do
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
     email { Faker::Internet.email }
+    phone_number { Faker::PhoneNumber.cell_phone }
     high_school { "#{ Faker::Address.city } High School" }
     year { ClubApplication.years.keys.sample.to_sym }
     github { Faker::Internet.user_name }

--- a/spec/models/club_application_spec.rb
+++ b/spec/models/club_application_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe ClubApplication, type: :model do
   it { should respond_to :first_name }
   it { should respond_to :last_name }
   it { should respond_to :email }
+  it { should respond_to :phone_number }
   it { should respond_to :high_school }
   it { should respond_to :year }
   it { should respond_to :github }


### PR DESCRIPTION
This PR adds a new field to the ClubApplication model. It enables us to collect the phone numbers of our new applicants who are more comfortable with a non-email form of communication.

Things to do:
- [x] Write some sort of copy which explains what we'll do with the phone number.
  - I'm not sure what this will look like, so going to talk to @kyleemile about it tomorrow.