### PR TITLE
Add intercom integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Secret keys are handled with [Figaro](https://github.com/laserlemon/figaro). Cre
 - `STRIPE_PUBLISHABLE_KEY` - Publishable key for [Stripe](https://stripe.com/)
 - `STRIPE_SECRET_KEY` - Secret key for [Stripe](https://stripe.com/)
 - `GOOGLE_MAPS_KEY` - JavaScript API key for Google Maps
+- `INTERCOM_APP_KEY` - App key for [Intercom](https://intercom.com)
 
 #### Production Secrets
 

--- a/app/views/club_applications/new.html.haml
+++ b/app/views/club_applications/new.html.haml
@@ -71,10 +71,4 @@
           = f.input :referer, label: 'How did you hear about us?'
     = f.button :submit, 'Submit Application'
 
-    :javascript
-      window.intercomSettings = {
-        app_id: "#{Figaro.env.INTERCOM_APP_KEY}"
-      }
-
-    :javascript
-      (function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.Intercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/'+window.intercomSettings;var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})()
+    = render 'layouts/intercom'

--- a/app/views/club_applications/new.html.haml
+++ b/app/views/club_applications/new.html.haml
@@ -70,3 +70,11 @@
         .columns
           = f.input :referer, label: 'How did you hear about us?'
     = f.button :submit, 'Submit Application'
+
+    :javascript
+      window.intercomSettings = {
+        app_id: "#{Figaro.env.INTERCOM_APP_KEY}"
+      }
+
+    :javascript
+      (function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.Intercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/'+window.intercomSettings;var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})()

--- a/app/views/club_applications/new.html.haml
+++ b/app/views/club_applications/new.html.haml
@@ -10,10 +10,10 @@
   .small-12.medium-9.small-centered.columns
     %p.apply-info
       We're currently accepting applications for the 2016 - 2017 school year.
-      If you have any questions, feel free to get in touch over Intercom (check
-      out the bottom right-hand corner) – we'll respond ASAP. You should
-      probably be writing over 3 sentences per response, just make sure you
-      don't write an essay!
+      If you have any questions, feel free to message us from the bottom
+      right-hand corner – we'll get back to you ASAP. You should probably be
+      writing over 3 sentences per response, just make sure you don't write an
+      essay!
     %p.apply-info
       Check out our
       = link_to 'example applications', '/example_applications'

--- a/app/views/club_applications/new.html.haml
+++ b/app/views/club_applications/new.html.haml
@@ -9,16 +9,15 @@
 .row
   .small-12.medium-9.small-centered.columns
     %p.apply-info
-      We're currently accepting applications for the 2016 - 2017 school year. If
-      you have any questions, don't hesitate to email us at
-      #{ link_to 'apply@hackclub.com' }. We look for 2-3 sentence responses to
-      each question. Good luck!
-
+      We're currently accepting applications for the 2016 - 2017 school year.
+      If you have any questions, feel free to get in touch over Intercom (check
+      out the bottom right-hand corner) – we'll respond ASAP. You should
+      probably be writing over 3 sentences per response, just make sure you
+      don't write an essay!
     %p.apply-info
       Check out our
       = link_to 'example applications', '/example_applications'
       if you want some help!
-
 .row
   = simple_form_for @application, url: apply_path do |f|
     %fieldset

--- a/app/views/layouts/_intercom.html.haml
+++ b/app/views/layouts/_intercom.html.haml
@@ -1,0 +1,9 @@
+:javascript
+  window.intercomSettings = {
+    app_id: "#{Figaro.env.INTERCOM_APP_KEY}"
+  }
+
+-# This is a snippet from Intercom's getting started guide.
+  Source: https://docs.intercom.com/install-on-your-product-or-site/quick-install/install-intercom-acquire-on-your-website
+:javascript
+  (function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.Intercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/'+window.intercomSettings.app_id;var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})()


### PR DESCRIPTION
This PR adds the Intercom bubble onto our application page. It allows us to have a direct line of communication between our website and our prospective club leaders. Hopefully it will assist in clearing up some of the misinformation which they are currently being fed.

~Intercom is currently configured to send a message to anyone who stays on the page for more than 60 seconds.~